### PR TITLE
Multiple Dockerfiles w/ less volume sharing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,0 @@
-FROM php:7-fpm
-
-VOLUME /var/www/html

--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -1,0 +1,3 @@
+FROM nginx
+
+COPY ./html /var/www/html

--- a/Dockerfile.php
+++ b/Dockerfile.php
@@ -1,0 +1,3 @@
+FROM php:7-fpm
+
+COPY ./html /var/www/html

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,22 @@
 version: "3"
 services:
   php:
-    build: .
+    build:
+      context: .
+      dockerfile: Dockerfile.php
     volumes:
-      - ./html:/var/www/html
+      - ./html/modules/custom:/var/www/html/modules/custom
+      - files:/var/www/html/sites/default/files
   web:
-    image: nginx
+    build:
+      context: .
+      dockerfile: Dockerfile.nginx
     links:
       - php
     ports:
       - "8888:80"
     volumes:
-      - php:/var/www/html
       - ./default.conf:/etc/nginx/conf.d/default.conf
+      - files:/var/www/html/sites/default/files
 volumes:
-  php:
+  files:


### PR DESCRIPTION
This builds ./html into the nginx container so that you don't need to share
those files in. It also demonstrates using two separate Dockerfiles so that you
can build files into the NGINX and PHP images separately.

Finally, this also shows how sites/default/files can be set up as a shared data
volume.